### PR TITLE
[TASK] Take silenced E_USER_* errors as silenced again

### DIFF
--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -18,7 +18,6 @@ use const E_USER_WARNING;
 use const E_WARNING;
 use function debug_backtrace;
 use function error_reporting;
-use function in_array;
 use function restore_error_handler;
 use function set_error_handler;
 use PHPUnit\Event;
@@ -44,8 +43,7 @@ final class ErrorHandler
     {
         $suppressed = !($errorNumber & error_reporting());
 
-        if ($suppressed &&
-            in_array($errorNumber, [E_DEPRECATED, E_NOTICE, E_STRICT, E_WARNING], true)) {
+        if ($suppressed) {
             return false;
         }
 


### PR DESCRIPTION
Basically, there are two ways to silence error levels:

* set error_reporting to a value, not containing the
  error levels which should be silenced/not displayed
* using the silence operator `@` to enforce silencing
  the error level, unrelated to the set error reporting
  level

For example, it's possible that `E_ALL` has been set
as global error_level() and therefore triggering a
user deprecation/warning/error using the `trigger_error`
method will be displayed. If the `@` silence operator
is used before the `trigger_error()` call, the error
is silenced.

```php
error_reporting(E_ALL);
trigger_error('', E_USER_DEPRECATED);  // will be shown
@trigger_error('', E_USER_DEPRECATED); // will not be shown
```

However, registered error handler will be called for all
errors, despite it has been silenced or not for both possible
ways to silence a error levels. ErrorHandler check the
passed `$errorNumber` against the result of error_reporting()
to determine if the errorNumber/errorLevel is supressed or
not. That check will also detect a errorNumber as beeing
silenced if the `@` silence operator has been used, which
could and should be taken as a intentional and enforced
silencing of an error (knowing that it would fail).

There are multple use-cases, where for e.g. silenced user
deprecation should not be taken as such, displayed and fail.

MockBuilder converts `@deprecated` method docblock annotations
to silenced `@trigger_error('', E_USER_DEPRECATED)` calls.
Having a `@deprecated` annonation does not mean, that the
original method call would trigger an `E_USER_DEPRECATED`
error - and it's arguable that it should be a hard enforcement
by PHPUnit to decide this and doing the conversion.

Therefore, this change removes the possible silenceable error
level list check from the `ErrorHander`. This restores how it
has worked in PHPUnit v9 without opening follow up issues.

This can be reintroduced, either in a configurable way or the
same if related questions has been properly thought about and
solved before:

* MockBuilder @deprecation -> trigger_error() configurable or
  removed
* proper way to configure between own code / 3rd party code
  if silenced error levels should be stay silenced or not.
  This means not only in one direction.

Related: #5325
